### PR TITLE
Add correlations of age to parameterized ratios

### DIFF
--- a/notebooks/5-EEG-Analysis.ipynb
+++ b/notebooks/5-EEG-Analysis.ipynb
@@ -23,6 +23,7 @@
     "\n",
     "import csv\n",
     "\n",
+    "import numpy as np\n",
     "import pandas as pd\n",
     "import seaborn as sns\n",
     "sns.set_context('talk')\n",
@@ -41,7 +42,7 @@
     "sys.path.append('../bratios')\n",
     "from bootstrap import bootstrap_corr, bootstrap_diff\n",
     "from utils import print_stat, print_stats, print_ap_corrs\n",
-    "from analysis import (get_all_data, nan_corr_spearman,\n",
+    "from analysis import (get_all_data, nan_corr_spearman, average_df,\n",
     "                      param_corr, param_ratio_corr, param_ratio_boot_corr)\n",
     "from plot import plot_param_ratio_corr, plot_param_ratio_corr_exp\n",
     "\n",
@@ -63,6 +64,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set random seed\n",
+    "np.random.seed(53)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -73,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {
     "scrolled": true
    },
@@ -97,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {
     "scrolled": false
    },
@@ -186,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -375,7 +386,7 @@
        "4  1.621394  6.952035  0.554800   0.071300          5.0  0.984456  "
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -418,42 +429,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Calculate the correlation between ratios and spectral features\n",
     "tbr_pe_rs, tbr_ap_rs, tbr_pe_cis, tbr_ap_cis, tbr_pe_ps, tbr_ap_ps = \\\n",
     "    param_ratio_boot_corr(df, \"TBR\", all_chans, corr_func=nan_corr_spearman)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Theta\n",
-      "\t CF \t -0.0040    [-0.1974, +0.1926]    0.9676\n",
-      "\t PW \t +0.3439    [+0.1431, +0.5155]    0.0003\n",
-      "\t BW \t +0.3137    [+0.1148, +0.4924]    0.0009\n",
-      "Alpha\n",
-      "\t CF \t -0.4181    [-0.5578, -0.2563]    0.0000\n",
-      "\t PW \t -0.0246    [-0.2133, +0.1693]    0.7978\n",
-      "\t BW \t +0.0190    [-0.1821, +0.2211]    0.8434\n",
-      "Beta\n",
-      "\t CF \t -0.0718    [-0.2634, +0.1256]    0.4537\n",
-      "\t PW \t -0.2841    [-0.4553, -0.0995]    0.0025\n",
-      "\t BW \t -0.0790    [-0.2601, +0.1087]    0.4101\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Print out statistics for the TBR\n",
-    "print_stats(tbr_pe_rs, tbr_pe_cis, tbr_pe_ps, BAND_NAMES, FEATURE_LABELS)"
    ]
   },
   {
@@ -465,9 +447,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Corr of TBR to Exp:    +0.77    [+0.6597, +0.8423]    0.0000\n",
-      "Corr of TBR to Off:    +0.76    [+0.6535, +0.8309]    0.0000\n",
-      "Corr of TBR to Age:    -0.67    [-0.7587, -0.5445]    0.0000\n"
+      "Theta\n",
+      "\t CF \t -0.0040    [-0.2004, +0.1912]    0.9676\n",
+      "\t PW \t +0.3439    [+0.1492, +0.5183]    0.0003\n",
+      "\t BW \t +0.3137    [+0.1158, +0.4907]    0.0009\n",
+      "Alpha\n",
+      "\t CF \t -0.4181    [-0.5569, -0.2533]    0.0000\n",
+      "\t PW \t -0.0246    [-0.2133, +0.1671]    0.7978\n",
+      "\t BW \t +0.0190    [-0.1779, +0.2156]    0.8434\n",
+      "Beta\n",
+      "\t CF \t -0.0718    [-0.2648, +0.1263]    0.4537\n",
+      "\t PW \t -0.2841    [-0.4581, -0.0869]    0.0025\n",
+      "\t BW \t -0.0790    [-0.2680, +0.1129]    0.4101\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Print out statistics for the TBR\n",
+    "print_stats(tbr_pe_rs, tbr_pe_cis, tbr_pe_ps, BAND_NAMES, FEATURE_LABELS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Corr of TBR to Exp:    +0.77    [+0.6572, +0.8427]    0.0000\n",
+      "Corr of TBR to Off:    +0.76    [+0.6508, +0.8316]    0.0000\n",
+      "Corr of TBR to Age:    -0.67    [-0.7579, -0.5435]    0.0000\n"
      ]
     }
    ],
@@ -478,7 +489,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -515,7 +526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -531,7 +542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -547,7 +558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -581,42 +592,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Calculate the correlation between ratios and spectral features\n",
     "tar_pe_rs, tar_ap_rs, tar_pe_cis, tar_ap_cis, tar_pe_ps, tar_ap_ps = \\\n",
     "    param_ratio_boot_corr(df, \"TAR\", all_chans, corr_func=nan_corr_spearman)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Theta\n",
-      "\t CF \t -0.3343    [-0.4887, -0.1615]    0.0004\n",
-      "\t PW \t -0.2049    [-0.3912, -0.0101]    0.0334\n",
-      "\t BW \t +0.2069    [+0.0166, +0.3792]    0.0317\n",
-      "Alpha\n",
-      "\t CF \t -0.0826    [-0.2734, +0.1133]    0.3890\n",
-      "\t PW \t -0.8934    [-0.9284, -0.8391]    0.0000\n",
-      "\t BW \t -0.1764    [-0.3515, +0.0065]    0.0641\n",
-      "Beta\n",
-      "\t CF \t +0.2152    [+0.0267, +0.3880]    0.0233\n",
-      "\t PW \t -0.3993    [-0.5622, -0.2127]    0.0000\n",
-      "\t BW \t -0.3164    [-0.4798, -0.1352]    0.0007\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Print out statistics for the TAR\n",
-    "print_stats(tar_pe_rs, tar_pe_cis, tar_pe_ps, BAND_NAMES, FEATURE_LABELS)"
    ]
   },
   {
@@ -628,9 +610,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Corr of TAR to Exp:    +0.26    [+0.0877, +0.4302]    0.0052\n",
-      "Corr of TAR to Off:    +0.26    [+0.0672, +0.4329]    0.0050\n",
-      "Corr of TAR to Age:    -0.37    [-0.5215, -0.2068]    0.0001\n"
+      "Theta\n",
+      "\t CF \t -0.3343    [-0.4872, -0.1617]    0.0004\n",
+      "\t PW \t -0.2049    [-0.3878, -0.0135]    0.0334\n",
+      "\t BW \t +0.2069    [+0.0147, +0.3770]    0.0317\n",
+      "Alpha\n",
+      "\t CF \t -0.0826    [-0.2731, +0.1050]    0.3890\n",
+      "\t PW \t -0.8934    [-0.9289, -0.8379]    0.0000\n",
+      "\t BW \t -0.1764    [-0.3497, +0.0073]    0.0641\n",
+      "Beta\n",
+      "\t CF \t +0.2152    [+0.0311, +0.3878]    0.0233\n",
+      "\t PW \t -0.3993    [-0.5616, -0.2172]    0.0000\n",
+      "\t BW \t -0.3164    [-0.4873, -0.1389]    0.0007\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Print out statistics for the TAR\n",
+    "print_stats(tar_pe_rs, tar_pe_cis, tar_pe_ps, BAND_NAMES, FEATURE_LABELS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Corr of TAR to Exp:    +0.26    [+0.0899, +0.4242]    0.0052\n",
+      "Corr of TAR to Off:    +0.26    [+0.0753, +0.4350]    0.0050\n",
+      "Corr of TAR to Age:    -0.37    [-0.5136, -0.2021]    0.0001\n"
      ]
     }
    ],
@@ -641,7 +652,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -678,7 +689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -694,7 +705,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -710,7 +721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -744,42 +755,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Calculate the correlation between ratios and spectral features\n",
     "abr_pe_rs, abr_ap_rs, abr_pe_cis, abr_ap_cis, abr_pe_ps, abr_ap_ps = \\\n",
     "    param_ratio_boot_corr(df, \"ABR\", all_chans, corr_func=nan_corr_spearman)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Theta\n",
-      "\t CF \t +0.3067    [+0.1219, +0.4656]    0.0012\n",
-      "\t PW \t +0.4508    [+0.2962, +0.5783]    0.0000\n",
-      "\t BW \t +0.0186    [-0.1755, +0.2155]    0.8481\n",
-      "Alpha\n",
-      "\t CF \t -0.2348    [-0.4071, -0.0451]    0.0131\n",
-      "\t PW \t +0.8685    [+0.7848, +0.9197]    0.0000\n",
-      "\t BW \t +0.1368    [-0.0602, +0.3296]    0.1522\n",
-      "Beta\n",
-      "\t CF \t -0.1995    [-0.3782, -0.0086]    0.0358\n",
-      "\t PW \t +0.1957    [+0.0038, +0.3746]    0.0396\n",
-      "\t BW \t +0.2642    [+0.0763, +0.4390]    0.0051\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Print out statistics for the ABR\n",
-    "print_stats(abr_pe_rs, abr_pe_cis, abr_pe_ps, BAND_NAMES, FEATURE_LABELS)"
    ]
   },
   {
@@ -791,9 +773,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Corr of ABR to Exp:    +0.32    [+0.1378, +0.4898]    0.0005\n",
-      "Corr of ABR to Off:    +0.30    [+0.1095, +0.4752]    0.0015\n",
-      "Corr of ABR to Age:    -0.12    [-0.2993, +0.0740]    0.2242\n"
+      "Theta\n",
+      "\t CF \t +0.3067    [+0.1256, +0.4658]    0.0012\n",
+      "\t PW \t +0.4508    [+0.2923, +0.5846]    0.0000\n",
+      "\t BW \t +0.0186    [-0.1717, +0.2139]    0.8481\n",
+      "Alpha\n",
+      "\t CF \t -0.2348    [-0.4057, -0.0510]    0.0131\n",
+      "\t PW \t +0.8685    [+0.7877, +0.9185]    0.0000\n",
+      "\t BW \t +0.1368    [-0.0627, +0.3274]    0.1522\n",
+      "Beta\n",
+      "\t CF \t -0.1995    [-0.3719, -0.0059]    0.0358\n",
+      "\t PW \t +0.1957    [+0.0078, +0.3733]    0.0396\n",
+      "\t BW \t +0.2642    [+0.0778, +0.4312]    0.0051\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Print out statistics for the ABR\n",
+    "print_stats(abr_pe_rs, abr_pe_cis, abr_pe_ps, BAND_NAMES, FEATURE_LABELS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Corr of ABR to Exp:    +0.32    [+0.1447, +0.4891]    0.0005\n",
+      "Corr of ABR to Off:    +0.30    [+0.1085, +0.4729]    0.0015\n",
+      "Corr of ABR to Age:    -0.12    [-0.3021, +0.0758]    0.2242\n"
      ]
     }
    ],
@@ -804,7 +815,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -841,7 +852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -857,7 +868,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -873,7 +884,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -898,14 +909,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\t Age-EXP corr  global:  \t -0.6807    [-0.7651, -0.5674]    0.0000\n"
+      "\t Age-EXP corr  global:  \t -0.6807    [-0.7693, -0.5698]    0.0000\n"
      ]
     }
    ],
@@ -917,16 +928,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\t Age-EXP corr  frontal:  \t -0.7032    [-0.7884, -0.5937]    0.0000\n",
-      "\t Age-EXP corr  central:  \t -0.6281    [-0.7375, -0.4867]    0.0000\n",
-      "\t Age-EXP corr  parietal:  \t -0.7101    [-0.7858, -0.6104]    0.0000\n"
+      "\t Age-EXP corr  frontal:  \t -0.7032    [-0.7892, -0.5964]    0.0000\n",
+      "\t Age-EXP corr  central:  \t -0.6281    [-0.7378, -0.4838]    0.0000\n",
+      "\t Age-EXP corr  parietal:  \t -0.7101    [-0.7835, -0.6103]    0.0000\n"
      ]
     }
    ],
@@ -949,16 +960,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\t Age: TBR vs EXP \t -0.0066    [-0.0165, +0.0034]    0.2004\n",
-      "\t Age: TAR vs EXP \t -0.2868    [-0.3048, -0.2683]    0.0000\n",
-      "\t Age: ABR vs EXP \t -0.5074    [-0.5252, -0.4889]    0.0000\n"
+      "\t Age: TBR vs EXP \t -0.0066    [-0.0163, +0.0030]    0.1792\n",
+      "\t Age: TAR vs EXP \t -0.2868    [-0.3047, -0.2687]    0.0000\n",
+      "\t Age: ABR vs EXP \t -0.5074    [-0.5252, -0.4897]    0.0000\n"
      ]
     }
    ],
@@ -971,17 +982,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\t Age: TBR vs TAR \t -0.2803    [-0.2982, -0.2636]    0.0000\n",
-      "\t Age: TBR vs ABR \t -0.5008    [-0.5180, -0.4828]    0.0000\n",
-      "\t Age: TAR vs ABR \t -0.2205    [-0.2526, -0.1887]    0.0000\n",
-      "\t Age: ABR vs TAR \t +0.2205    [+0.1892, +0.2524]    0.0000\n"
+      "\t Age: TBR vs TAR \t -0.2803    [-0.2978, -0.2636]    0.0000\n",
+      "\t Age: TBR vs ABR \t -0.5008    [-0.5179, -0.4838]    0.0000\n",
+      "\t Age: TAR vs ABR \t -0.2205    [-0.2514, -0.1901]    0.0000\n",
+      "\t Age: ABR vs TAR \t +0.2205    [+0.1892, +0.2520]    0.0000\n"
      ]
     }
    ],
@@ -992,6 +1003,53 @@
     "        if ratio1 == ratio2: continue\n",
     "        print_stat('Age: {} vs {}'.format(ratio1, ratio2), \n",
     "               *bootstrap_diff(df[\"Age\"].values, df[ratio1].values, df[ratio2].values))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also consider the possibility of updated ratio measures, that compute the ratio of parameterized band powers. \n",
+    "\n",
+    "To briefly examine such measures, we will calculate 'parameterized ratios', and compare them to age."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Calculate parameterized ratios\n",
+    "avg_df = average_df(df, all_chans)\n",
+    "param_tbr = avg_df[\"Theta_PW\"].values / avg_df[\"Beta_PW\"].values\n",
+    "param_tar = avg_df[\"Theta_PW\"].values / avg_df[\"Alpha_PW\"].values\n",
+    "param_abr = avg_df[\"Alpha_PW\"].values / avg_df[\"Beta_PW\"].values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\t P-TBR & Age: \t -0.1221    [-0.2866, +0.0537]    0.2080\n",
+      "\t P-TAR & Age: \t -0.1314    [-0.3053, +0.0597]    0.1752\n",
+      "\t P-ABR & Age: \t -0.0848    [-0.2741, +0.1136]    0.3760\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compare Correlations of Parameterized Ratios with Age\n",
+    "print_stat('P-TBR & Age:', *bootstrap_corr(\n",
+    "    avg_df[\"Age\"].values, param_tbr, func=nan_corr_spearman))\n",
+    "print_stat('P-TAR & Age:', *bootstrap_corr(\n",
+    "    avg_df[\"Age\"].values, param_tar, func=nan_corr_spearman))\n",
+    "print_stat('P-ABR & Age:', *bootstrap_corr(\n",
+    "    avg_df[\"Age\"].values, param_abr, func=nan_corr_spearman))"
    ]
   }
  ],


### PR DESCRIPTION
So, @ArcadeShrimp, I did the checks I wanted of the parameterized ratios, and correlating them with age, etc. 

This adds the correlation of age to parameterized ratios, and finds them to be non-significant (~0), which is what we expected, to report in the review. You can see this at the bottom of the updated notebook #5. 

Interestingly, the correlational structure all make seems to make more sense now, a bit different to what we were seeing before. I didn't leave it in the notebook, but here is the correlation of the parameterized ratio to the other features, the results of which make a lot more sense to what we were seeing before. 
![Screen Shot 2020-07-24 at 10 02 40 PM](https://user-images.githubusercontent.com/7727566/88449211-e0c85e80-cdf9-11ea-8342-a22c85a9c913.png)

I'm not sure why your notebook was different. Some of it is the group averaging, though I don't think all of it. But since it seems to be working / makes sense now, I don't think we need to worry about it. 